### PR TITLE
Fix selinuxfs.c when changing to force permissive

### DIFF
--- a/security/selinux/selinuxfs.c
+++ b/security/selinux/selinuxfs.c
@@ -194,7 +194,6 @@ static ssize_t sel_write_enforce(struct file *file, const char __user *buf,
 		if (!selinux_enforcing)
 			call_lsm_notifier(LSM_POLICY_CHANGE, NULL);
 	}
-#endif
 // ] SEC_SELINUX_PORTING_COMMON
 	length = count;
 out:


### PR DESCRIPTION
Compiling with force permissive causes errors because of an extra endif

